### PR TITLE
refactor: Clearing out aria properties from Banner button

### DIFF
--- a/cypress/integration/Banner.spec.ts
+++ b/cypress/integration/Banner.spec.ts
@@ -18,20 +18,6 @@ describe('Banner', () => {
       it('should have an element with a role of "button"', () => {
         cy.findByRole('button').should('be.visible');
       });
-
-      it('should have an "aria-labelledby" that matches the action', () => {
-        cy.findByRole('button').then($button => {
-          const id = $button.attr('aria-labelledby');
-          cy.findByText('View All').should('have.attr', 'id', id);
-        });
-      });
-
-      it('should have an "aria-describedby" that matches the label', () => {
-        cy.findByRole('button').then($button => {
-          const id = $button.attr('aria-describedby');
-          cy.findByText('3 Errors').should('have.attr', 'id', id);
-        });
-      });
     });
   });
 });

--- a/modules/react/banner/lib/Banner.tsx
+++ b/modules/react/banner/lib/Banner.tsx
@@ -13,7 +13,7 @@ import {
 } from '@workday/canvas-kit-react/common';
 import {Flex} from '@workday/canvas-kit-react/layout';
 
-import {useBanner, useBannerModel, useThemedPalette} from './hooks';
+import {useBannerModel, useThemedPalette} from './hooks';
 
 import {BannerIcon} from './BannerIcon';
 import {BannerLabel} from './BannerLabel';

--- a/modules/react/banner/lib/Banner.tsx
+++ b/modules/react/banner/lib/Banner.tsx
@@ -70,7 +70,6 @@ const styles: CSSProperties = {
 export const Banner = createContainer('button')({
   displayName: 'Banner',
   modelHook: useBannerModel,
-  elemPropsHook: useBanner,
   subComponents: {
     /**
      * `Banner.Icon` is a styled {@link SystemIcon}. The icon defaults to exclamationTriangleIcon or


### PR DESCRIPTION
<!-- Thank you for your pull request, please provide a brief summary of what this introduces (mandatory). Please point out any code that may be non-obvious to reviewers by using in-code comments. -->

## Summary

The `useBanner` hook is adding the aria-labelledby and aria-describedby properties to the Banner button element. I removed the call to the hook so the aria attributes are not applied. 

<!-- For bug fixes, use "Fixes". For new features use "Resolves". This helps link a PR to an issue and will show up in release notes. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? Anything in the Summary section will be attached to the squashed commit when this PR is merged. -->

The Banner button is using aria-labelledby referencing the ActionText, and aria-describedby referencing the LabelText sub-component. It is difficult to point to measurable "problems" with this, because it does sound nice with screen readers. When `isSticky` prop is used, the ActionText disappears from the screen, while still being referenced as the main label for the button. 

This will break the experience for Dragon Dictation and Voice Control users because the visible LabelText is not being used as the accessible name of the button element. 

<!-- This is the category in the release notes. Common categories are Components, Infrastructure, Documentation, Dependencies, Codemods, and Tokens -->
## Release Category
Components

### Release Note
Optional release note message. Changelog and release summaries will contain a pull request title. This section will add additional notes under that title. This section is not a summary, but something extra to point out in release notes. An example might be calling out breaking changes in a labs component or minor visual changes that need visual regression updates. Remove this section if no additional release notes are required.

### BREAKING CHANGES
Optional breaking changes message. If your PR includes breaking changes. It is extremely rare to put breaking changes outside a `prerelease/major` branch. Anything in this section will show up in release notes. Remove this section if no breaking changes are present.

---

## Checklist

- [ ] MDX documentation adheres to Canvas Kit's [Documentation Guidelines](https://workday.github.io/canvas-kit/?path=/docs/guides-documentation-guidelines--page)
- [ ] Label `ready for review` has been added to PR

## For the Reviewer

<!-- Provide a bit of context about what this PR does. Add any additional checklist items you'd like the reviewer to check -->

- [ ] PR title is short and descriptive
- [ ] PR summary describes the change (Fixes/Resolves linked correctly)
- [ ] PR Release Notes describes additional information useful to call out in a release message or removed if not applicable
- [ ] Breaking Changes provides useful information to upgrade to this code or removed if not applicable

## Where Should the Reviewer Start?

<!-- If you were reviewing this PR, where would you want to start?  -->
<!-- e.g. `/modules/react/common/lib/utils/someUtil.ts`  -->

Only changed `Banner.tsx`; I forgot to delete the import; observed `useBanner` hook is returning the object with aria attributes;

## Areas for Feedback? (optional)

<!-- Do you have any particular areas where you'd like additional focus or feedback from reviewers? -->

- [ ] Code
- [ ] Documentation
- [ ] Testing
- [ ] Codemods

<!-- If you would like to provide more context for where you'd like reviewer feedback, or if there are areas where you specifically do not want feedback, please describe below.  -->
## Testing Manually

<!-- Explain how your reviewer could verify this change  -->

1. Navigate to Storybook > Banner examples, 
2. Inspect the Banner button element, 
3. Validate that both aria-labelledby and aria-describedby are NOT set on the button, 
4. Inspect the accessibility tree, and the name computation, 
5. Validate the `name:` computes with the button element inner text strings. 
6. Use the `isSticky` prop, 
7. Repeat steps 4 - 5 again to validate the visible text in the button matches the computed `name:`. 

## Screenshots or GIFs (if applicable)

<!-- Does your change affect the UI? If so, please include a screenshot or short gif. -->
No change to the UI; aria does not impact UI. 

## Thank You Gif (optional)

<!-- Share a fun [gif](https://giphy.com) to say thanks to your reviewer! -->
<!-- ![a smiling Shiba Inu typing on a laptop](https://media.giphy.com/media/mCRJDo24UvJMA/giphy.gif) -->
